### PR TITLE
fix use of __GNUC__ for gcc detection

### DIFF
--- a/include/boost/parser/detail/printing_impl.hpp
+++ b/include/boost/parser/detail/printing_impl.hpp
@@ -3,15 +3,17 @@
 
 #include <boost/parser/detail/printing.hpp>
 
+#include <boost/config.hpp>
+
 #if __has_include(<boost/type_index.hpp>)
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(BOOST_GCC) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 #include <boost/type_index.hpp>
 #define BOOST_PARSER_HAVE_BOOST_TYPEINDEX 1
 #define BOOST_PARSER_TYPE_NAME_NS boost_type_index
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(BOOST_GCC) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 #else

--- a/include/boost/parser/detail/stl_interfaces/view_adaptor.hpp
+++ b/include/boost/parser/detail/stl_interfaces/view_adaptor.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/parser/detail/detection.hpp>
 
+#include <boost/config.hpp>
 #include <tuple>
 #include <type_traits>
 
@@ -24,8 +25,9 @@
 #define BOOST_PARSER_USE_CPP23_STD_RANGE_ADAPTOR_CLOSURE 0
 #endif
 
-#if !BOOST_PARSER_USE_CPP23_STD_RANGE_ADAPTOR_CLOSURE &&               \
-    BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS && defined(__GNUC__) && 12 <= __GNUC__
+#if !BOOST_PARSER_USE_CPP23_STD_RANGE_ADAPTOR_CLOSURE &&                       \
+    BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS &&                         \
+    defined(BOOST_LIBSTDCXX_VERSION) && 13000 > BOOST_LIBSTDCXX_VERSION
 #define BOOST_PARSER_USE_LIBSTDCPP_GCC12_RANGE_ADAPTOR_CLOSURE 1
 #else
 #define BOOST_PARSER_USE_LIBSTDCPP_GCC12_RANGE_ADAPTOR_CLOSURE 0

--- a/include/boost/parser/detail/text/detail/all_t.hpp
+++ b/include/boost/parser/detail/text/detail/all_t.hpp
@@ -10,6 +10,7 @@
 #include <boost/parser/detail/text/detail/begin_end.hpp>
 #include <boost/parser/detail/detection.hpp>
 
+#include <boost/config.hpp>
 #include <array>
 #if BOOST_PARSER_USE_CONCEPTS
 #include <ranges>
@@ -42,7 +43,8 @@ namespace boost::parser::detail::text::detail {
     template<typename R>
     constexpr bool view =
 #if BOOST_PARSER_DETAIL_TEXT_USE_CONCEPTS ||                                   \
-    (defined(__cpp_lib_concepts) && (!defined(__GNUC__) || 12 <= __GNUC__))
+    (defined(__cpp_lib_concepts) &&                                            \
+     !(defined(BOOST_LIBSTDCXX_VERSION) && 13000 > BOOST_LIBSTDCXX_VERSION))
         std::ranges::view<R>
 #else
         range_<R> && !container_<R> &&

--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -21,6 +21,7 @@
 #include <boost/parser/detail/text/trie_map.hpp>
 #include <boost/parser/detail/text/unpack.hpp>
 
+#include <boost/config.hpp>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -9539,7 +9540,7 @@ namespace boost { namespace parser {
         {
             // This code chokes older GCCs.  I can't figure out why, and this
             // is an optional check, so I'm disabling it for those GCCs.
-#if !defined(__GNUC__) || 13 <= __GNUC__
+#if !(defined(BOOST_GCC) && 13 <= __GNUC__)
             using context_t = parse_context<
                 false,
                 false,

--- a/include/boost/parser/transform_replace.hpp
+++ b/include/boost/parser/transform_replace.hpp
@@ -3,8 +3,10 @@
 
 #include <boost/parser/replace.hpp>
 
+#include <boost/config.hpp>
+
 #if (!defined(_MSC_VER) || BOOST_PARSER_USE_CONCEPTS) &&                       \
-    (!defined(__GNUC__) || 12 <= __GNUC__ || !BOOST_PARSER_USE_CONCEPTS)
+    (!(defined(BOOST_GCC) && 12 <= __GNUC__) || !BOOST_PARSER_USE_CONCEPTS)
 
 
 namespace boost::parser {

--- a/include/boost/parser/tuple.hpp
+++ b/include/boost/parser/tuple.hpp
@@ -12,19 +12,20 @@
 
 #if BOOST_PARSER_USE_STD_TUPLE
 
+#include <boost/config.hpp>
 #include <tuple>
 
 #else
 
 // Silence very verbose warnings about std::is_pod/std::is_literal being
 // deprecated.
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(BOOST_GCC) || defined(__clang__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #    pragma GCC diagnostic ignored "-Wunused-value"
 #endif
 #include <boost/hana.hpp>
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(BOOST_GCC) || defined(__clang__)
 #    pragma GCC diagnostic pop
 #endif
 
@@ -185,7 +186,7 @@ namespace boost { namespace parser {
             template<typename T>
             operator T() const && noexcept
             {
-#if defined(__GNUC__) && __GNUC__ < 13
+#if defined(BOOST_GCC) && __GNUC__ < 13
                 // Yuck.
                 std::remove_reference_t<T> * ptr = nullptr;
                 ptr += 1; // warning mitigation

--- a/test/replace.cpp
+++ b/test/replace.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/parser/replace.hpp>
 
+#include <boost/config.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 #include "ill_formed.hpp"
@@ -134,7 +135,7 @@ int main()
         }
         BOOST_TEST(count == 4);
     }
-#if !defined(__GNUC__) || 12 <= __GNUC__
+#if !(defined(BOOST_LIBSTDCXX_VERSION) && 13000 > BOOST_LIBSTDCXX_VERSION)
     // Older GCCs don't like the use of temporaries like the
     // std::string("foo") below.
     {
@@ -380,7 +381,7 @@ int main()
     }
 }
 
-#if BOOST_PARSER_USE_CONCEPTS && (!defined(__GNUC__) || 12 <= __GNUC__)
+#if BOOST_PARSER_USE_CONCEPTS && !(defined(BOOST_LIBSTDCXX_VERSION) && 13000 > BOOST_LIBSTDCXX_VERSION)
 // Older GCCs don't like the use of temporaries like the std::string("foo")
 // below.  This causes | join to break.
 // join_compat)
@@ -453,7 +454,7 @@ int main()
         std::cout << "\n";
         assert(count == 3);
     }
-#if BOOST_PARSER_USE_CONCEPTS && (!defined(__GNUC__) || 12 <= __GNUC__)
+#if BOOST_PARSER_USE_CONCEPTS && !(defined(BOOST_LIBSTDCXX_VERSION) && 13000 > BOOST_LIBSTDCXX_VERSION)
     {
         namespace bp = boost::parser;
         auto card_number = bp::int_ >> bp::repeat(3)['-' >> bp::int_];

--- a/test/transform_replace.cpp
+++ b/test/transform_replace.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/parser/transform_replace.hpp>
 
+#include <boost/config.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 #include "ill_formed.hpp"
@@ -15,7 +16,7 @@
 #include <list>
 
 #if (!defined(_MSC_VER) || BOOST_PARSER_USE_CONCEPTS) &&                       \
-    (!defined(__GNUC__) || 12 <= __GNUC__ || !BOOST_PARSER_USE_CONCEPTS)
+    (!(defined(BOOST_GCC) && 12 <= __GNUC__) || !BOOST_PARSER_USE_CONCEPTS)
 
 namespace bp = boost::parser;
 
@@ -681,7 +682,7 @@ int main()
     }
 }
 
-#if BOOST_PARSER_USE_CONCEPTS && (!defined(__GNUC__) || 12 <= __GNUC__)
+#if BOOST_PARSER_USE_CONCEPTS && !(defined(BOOST_LIBSTDCXX_VERSION) && 13000 > BOOST_LIBSTDCXX_VERSION)
 // Older GCCs don't like the use of temporaries like the std::string("foo")
 // below.  This causes | join to break.
 // join_compat)


### PR DESCRIPTION
`__GNUC__` is not useable to detect presence of gcc, nor has it ever been. It represents *the current version of the GNU C language extensions, as implemented by gcc of the respective major version*.

Accordingly, clang defines `__GNUC__` to 5, which breaks a lot of your compiler checks.

Detecting gcc is actually quite nontrivial as it doesn't expose a nice macro like clang does with `__clang__`, hence I used `BOOST_GCC` and `BOOST_LIBSTDCXX_VERSION` from `boost/config.hpp` accordingly.

In some cases I was unsure if you encountered an issue with concepts support in old gcc, or incomplete ranges support in old libstdc++. Particularly in `replace` and `transform_replace`.