### PR TITLE
Add fast-path for lower case ASCII letters in case_fold

### DIFF
--- a/include/boost/parser/detail/case_fold.hpp
+++ b/include/boost/parser/detail/case_fold.hpp
@@ -47,7 +47,10 @@ namespace boost::parser::detail {
         // One-byte fast path.
         if (cp < 0x100) {
             // ASCII letter fast path.
-            if (0x41 <= cp && cp < 0x5a) {
+            if (0x61 <= cp && cp < 0x7a) {
+                *out++ = cp;
+                return out;
+            } else if (0x41 <= cp && cp < 0x5a) {
                 *out++ = cp + 0x20;
                 return out;
             } else if (cp == 0x00DF) {


### PR DESCRIPTION
This improved the speed of my parser by approximately 20%

There is a fast-path in case_fold for uppercase ASCII letters to convert them to lowercase ASCII letters. But there is not fast-path to keep lowercase ASCII letters. Am I missing something here?