### PR TITLE
Performance improvement: Do not copy use_parser into lambda

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -3389,7 +3389,7 @@ namespace boost { namespace parser {
 
             bool done = false;
             auto try_parser = [prev_first = first,
-                               use_parser,
+                               &use_parser,
                                &success,
                                flags,
                                &retval,


### PR DESCRIPTION
I don't see a reason why the use_parser structure is copied into the lambda. It is not used outside of the lambda, so the lambda might as well use the object existing outside.

This gave me a few percent performance improvement. The use_parser_t structure is quite heavy.