### PR TITLE
Do not call skip parser if we are already in failed state in seq_parser

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -4352,11 +4352,11 @@ namespace boost { namespace parser {
                                &success,
                                &retval](auto const &
                                             parser_index_merged_and_backtrack) {
+                if (!success) // Someone earlier already failed...
+                    return;
                 auto flags = flags_;
                 using namespace literals;
                 detail::skip(first, last, skip, flags);
-                if (!success) // Someone earlier already failed...
-                    return;
 
                 auto const & parser =
                     parser::get(parser_index_merged_and_backtrack, 0_c);


### PR DESCRIPTION
Now this gave me more than 10% speedup.

Currently, the seq_parser calls the skip-parser for each child, even if we are already failed.