### PR TITLE
Add repeat_directive::operator() to allow repeat with delimiter

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -3087,6 +3087,23 @@ namespace boost { namespace parser {
 
                 for (int64_t end = detail::resolve(context, min_); count != end;
                      ++count) {
+                    if constexpr (!detail::is_nope_v<DelimiterParser>) {
+                        if (count != 0) {
+                            detail::skip(first, last, skip, flags);
+                            delimiter_parser_.call(
+                                first,
+                                last,
+                                context,
+                                skip,
+                                detail::disable_attrs(flags),
+                                success);
+                            if (!success) {
+                                detail::assign(retval, Attribute());
+                                return;
+                            }
+                        }
+                    }
+
                     detail::skip(first, last, skip, flags);
                     attr_t attr{};
                     parser_.call(
@@ -6403,6 +6420,16 @@ namespace boost { namespace parser {
                 repeat_parser<Parser2, detail::nope, MinType, MaxType>;
             return parser_interface{
                 repeat_parser_type{rhs.parser_, min_, max_}};
+        }
+
+
+        template<typename Parser2, typename DelimiterParser>
+        constexpr auto operator()(parser_interface<Parser2> rhs, parser_interface<DelimiterParser> delim) const noexcept
+        {
+            using repeat_parser_type =
+                repeat_parser<Parser2, DelimiterParser, MinType, MaxType>;
+            return parser_interface{
+                repeat_parser_type{rhs.parser_, min_, max_, delim.parser_}};
         }
 
         MinType min_;

--- a/test/github_issues.cpp
+++ b/test/github_issues.cpp
@@ -287,6 +287,24 @@ void github_issue_223()
     }
 }
 
+void github_issue_231()
+{
+    namespace bp = boost::parser;
+
+    constexpr auto parser = bp::repeat(3,5)(+bp::char_('a', 'z'), bp::lit(','));
+
+    auto result = bp::parse("hello, world, ", parser, bp::ws);
+    BOOST_TEST(!result.has_value());
+    result = bp::parse("hello, world, there", parser, bp::ws);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(result->size() == 3);
+    result = bp::parse("hello, world, there, foo, nix", parser, bp::ws);
+    BOOST_TEST(result.has_value());
+    BOOST_TEST(result->size() == 5);
+    result = bp::parse("hello, world, there, foo, nix, bar", parser, bp::ws);
+    BOOST_TEST(!result.has_value());
+}
+
 namespace github_issue_248_ {
     namespace bp = boost::parser;
 
@@ -355,6 +373,7 @@ int main()
     github_issue_125();
     github_issue_209();
     github_issue_223();
+    github_issue_231();
     github_issue_248();
     return boost::report_errors();
 }


### PR DESCRIPTION
Implement request in https://github.com/boostorg/parser/issues/231

I think this is what @psiha is asking for.

I implemented it in operator() to pass two parsers to repeat_directive. This is not so nice. But with operator[] we get only one argument. Do you have any other idea?