### PR TITLE
Add define BOOST_PARSER_DISABLE_TRACE to disable trace mode at compile time

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,6 +18,13 @@ jobs:
         compiler_version: [g++-10, g++-11]
         cxx_std: [17, 20]
         os: [ubuntu-22.04]
+        disable_trace: [false]
+        include:
+          # Test with trace disabled
+          - compiler_version: g++-11
+            cxx_std: 20
+            os: ubuntu-22.04
+            disable_trace: true
 
     runs-on: ${{ matrix.os }}
 
@@ -30,7 +37,11 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler_version }} -DCXX_STD=${{ matrix.cxx_std }}
+          if [ "${{ matrix.disable_trace }}" = "true" ]; then
+            cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler_version }} -DCXX_STD=${{ matrix.cxx_std }} -DDISABLE_TRACE=true
+          else
+            cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler_version }} -DCXX_STD=${{ matrix.cxx_std }}
+          fi
 
       - name: Build
         run: cd build ; make -j4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,12 @@ jobs:
       matrix:
         cxx_std: [17, 20, 23]
         os: [windows-2022]
+        disable_trace: [false]
+        include:
+          # Test with trace disabled
+          - cxx_std: 20
+            os: windows-2022
+            disable_trace: true
 
     runs-on: ${{ matrix.os }}
 
@@ -26,7 +32,13 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. Visual Studio is a multi-config generator, so we don't use CMAKE_BUILD_TYPE.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B build -DCXX_STD=${{ matrix.cxx_std }}
+        run: |
+          if ("${{ matrix.disable_trace }}" -eq "true") {
+            cmake -B build -DCXX_STD=${{ matrix.cxx_std }} -DDISABLE_TRACE=true
+          } else {
+            cmake -B build -DCXX_STD=${{ matrix.cxx_std }}
+          }
+        shell: pwsh
 
       - name: Build
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,12 @@ if (BUILD_WITH_HANA)
   add_definitions(-DBOOST_PARSER_USE_HANA_TUPLE)
 endif()
 
+set(DISABLE_TRACE false CACHE BOOL
+    "Disable parser trace functionality (defines BOOST_PARSER_DISABLE_TRACE).")
+if (DISABLE_TRACE)
+  add_definitions(-DBOOST_PARSER_DISABLE_TRACE)
+endif()
+
 
 ##################################################
 # Dependencies

--- a/doc/parser.qbk
+++ b/doc/parser.qbk
@@ -148,6 +148,7 @@
 [def _RULES_               [macroref BOOST_PARSER_DEFINE_RULES `BOOST_PARSER_DEFINE_RULES`]]
 [def _AGGR_SIZE_           [macroref BOOST_PARSER_MAX_AGGREGATE_SIZE `BOOST_PARSER_MAX_AGGREGATE_SIZE`]]
 [def _SUBRNG_              [macroref BOOST_PARSER_SUBRANGE `BOOST_PARSER_SUBRANGE`]]
+[def _DISABLE_TRACE_       [macroref BOOST_PARSER_DISABLE_TRACE `BOOST_PARSER_DISABLE_TRACE`]]
 
 [def __p_                  [globalref boost::parser::_p `_p`]]
 

--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -3766,6 +3766,22 @@ Some things to be aware of when looking at _Parser_ trace output:
   produces that value.  In these cases, you'll see the resolved value of the
   parse argument.
 
+[heading Compile-time trace disabling]
+
+While trace mode is very useful for debugging, it does have some overhead.
+Most parser templates are instantiated twice: Once with tracing enabled,
+once with tracing disabled.
+If you want to completely disable trace functionality at compile time, you can define
+`BOOST_PARSER_DISABLE_TRACE` before including any Boost.Parser headers:
+
+[teletype]``
+#define BOOST_PARSER_DISABLE_TRACE
+#include <boost/parser/parser.hpp>
+``
+
+When this define is set, all trace-related code is compiled out,
+reducing the compile time.
+
 [endsect]
 
 [section Memory Allocation]
@@ -3983,7 +3999,8 @@ This defines a RAII trace object that will produce the verbose trace requested
 by the user if they passed `_trace_::on` to the top-level parse.  It only has
 effect if `detail::enable_trace(flags)` is `true`.  If trace is enabled, it
 will show the state of the parse at the point at which it is defined, and then
-again when it goes out of scope.
+again when it goes out of scope. By defining `BOOST_PARSER_DISABLE_TRACE`,
+the trace feature can be disabled globally at compile time.
 
 [important For the tracing code to work, you must define an overload of
 `detail::print_parser` for your new parser type/template.  See

--- a/include/boost/parser/detail/printing.hpp
+++ b/include/boost/parser/detail/printing.hpp
@@ -598,6 +598,7 @@ namespace boost { namespace parser { namespace detail {
     template<typename Context>
     auto resolve(Context const &, nope n);
 
+    #ifndef BOOST_PARSER_DISABLE_TRACE
     template<
         bool DoTrace,
         typename Iter,
@@ -708,6 +709,7 @@ namespace boost { namespace parser { namespace detail {
         }
         os << "--------------------" << std::endl;
     }
+    #endif // BOOST_PARSER_DISABLE_TRACE
 
 }}}
 

--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -2455,8 +2455,10 @@ namespace boost { namespace parser {
                     flags,
                     success,
                     attr);
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 if (Debug)
                     detail::final_trace(context, flags, attr);
+                #endif // BOOST_PARSER_DISABLE_TRACE
                 return success;
             } catch (parse_error<Iter> const & e) {
                 if (error_handler(initial_first, last, e) ==
@@ -2509,8 +2511,10 @@ namespace boost { namespace parser {
                     detail::null_parser{},
                     flags,
                     success);
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 if (Debug)
                     detail::final_trace(context, flags, nope{});
+                #endif // BOOST_PARSER_DISABLE_TRACE
                 return detail::make_parse_result(attr_, success);
             } catch (parse_error<Iter> const & e) {
                 if (error_handler(initial_first, last, e) ==
@@ -2564,8 +2568,10 @@ namespace boost { namespace parser {
                     detail::null_parser{},
                     flags,
                     success);
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 if (Debug)
                     detail::final_trace(context, flags, nope{});
+                #endif // BOOST_PARSER_DISABLE_TRACE
                 return success;
             } catch (parse_error<Iter> const & e) {
                 if (error_handler(initial_first, last, e) ==
@@ -2615,8 +2621,10 @@ namespace boost { namespace parser {
             try {
                 parser(first, last, context, skip, flags, success, attr);
                 detail::skip(first, last, skip, flags);
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 if (Debug)
                     detail::final_trace(context, flags, attr);
+                #endif // BOOST_PARSER_DISABLE_TRACE
                 return success;
             } catch (parse_error<Iter> const & e) {
                 if (error_handler(initial_first, last, e) ==
@@ -2668,8 +2676,10 @@ namespace boost { namespace parser {
                 attr_t attr_ =
                     parser(first, last, context, skip, flags, success);
                 detail::skip(first, last, skip, flags);
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 if (Debug)
                     detail::final_trace(context, flags, nope{});
+                #endif // BOOST_PARSER_DISABLE_TRACE
                 return detail::make_parse_result(attr_, success);
             } catch (parse_error<Iter> const & e) {
                 if (error_handler(initial_first, last, e) ==
@@ -2721,8 +2731,10 @@ namespace boost { namespace parser {
             try {
                 parser(first, last, context, skip, flags, success);
                 detail::skip(first, last, skip, flags);
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 if (Debug)
                     detail::final_trace(context, flags, nope{});
+                #endif // BOOST_PARSER_DISABLE_TRACE
                 return success;
             } catch (parse_error<Iter> const & e) {
                 if (error_handler(initial_first, last, e) ==
@@ -3177,6 +3189,7 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this,
                 first,
@@ -3185,6 +3198,7 @@ namespace boost { namespace parser {
                 detail::in_apply_parser(flags) ? detail::disable_trace(flags)
                                                : flags,
                 retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if constexpr (detail::is_optional_v<Attribute>) {
                 detail::optional_type<Attribute> attr;
@@ -3341,8 +3355,10 @@ namespace boost { namespace parser {
             Attribute & retval) const
         {
             //[ opt_parser_trace
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             //]
 
             //[ opt_parser_skip
@@ -3505,8 +3521,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             use_parser_t<Iter, Sentinel, Context, SkipParser> const use_parser{
                 first, last, context, skip, flags, success};
@@ -3629,8 +3647,10 @@ namespace boost { namespace parser {
                 decltype(detail::hl::transform(parsers_, use_parser));
             result_t retval{};
 
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first_, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             call_impl(
                 first,
@@ -3665,8 +3685,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first_, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             Iter first = first_;
             use_parser_t<Iter, Sentinel, Context, SkipParser> const use_parser{
@@ -4298,6 +4320,7 @@ namespace boost { namespace parser {
             std::decay_t<decltype(parser::get(temp_result, llong<0>{}))>
                 retval{};
 
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this,
                 first_,
@@ -4306,6 +4329,7 @@ namespace boost { namespace parser {
                 detail::in_apply_parser(flags) ? detail::disable_trace(flags)
                                                : flags,
                 retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             std::decay_t<decltype(parser::get(temp_result, llong<1>{}))>
                 indices;
@@ -4349,6 +4373,7 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this,
                 first_,
@@ -4357,6 +4382,7 @@ namespace boost { namespace parser {
                 detail::in_apply_parser(flags) ? detail::disable_trace(flags)
                                                : flags,
                 retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             Iter first = first_;
 
@@ -4703,8 +4729,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             auto const initial_first = first;
             auto attr = parser_.call(
@@ -4769,8 +4797,10 @@ namespace boost { namespace parser {
             detail::flags flags,
             bool & success) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, detail::global_nope);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             auto attr =
                 parser_.call(first, last, context, skip, flags, success);
             if (success && detail::gen_attrs(flags))
@@ -4794,8 +4824,11 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
+
             auto attr =
                 parser_.call(first, last, context, skip, flags, success);
             if (success && detail::gen_attrs(flags))
@@ -4822,8 +4855,10 @@ namespace boost { namespace parser {
             detail::flags flags,
             bool & success) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, detail::global_nope);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             parser_.call(
                 first,
@@ -4850,8 +4885,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             parser_.call(
                 first,
@@ -4901,8 +4938,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             auto const initial_first = first;
             parser_.call(
@@ -4966,8 +5005,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             auto const initial_first = first;
             parser_.call(
@@ -5042,8 +5083,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             parser_.call(
                 first,
@@ -5102,8 +5145,10 @@ namespace boost { namespace parser {
             auto context = context_;
             ++context.no_case_depth_;
 
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             parser_.call(first, last, context, skip, flags, success, retval);
         }
@@ -5149,8 +5194,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if constexpr (detail::is_nope_v<SkipParser>) {
                 parser_.call(
@@ -5213,8 +5260,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             auto first_copy = first;
             parser_.call(
@@ -5380,8 +5429,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             auto [trie, _0] = detail::get_trie(context, ref());
             auto const lookup = context.no_case_depth_
@@ -5455,8 +5506,10 @@ namespace boost { namespace parser {
             tag_type * const tag_ptr = nullptr;
             auto const rule_context = detail::make_rule_context(
                 context, tag_ptr, retval, locals, params);
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, rule_context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             bool dont_assign = false;
             if constexpr (in_recursion) {
@@ -5553,8 +5606,10 @@ namespace boost { namespace parser {
                 auto const rule_context = detail::make_rule_context(
                     context, tag_ptr, attr, locals, params);
 
+                #ifndef BOOST_PARSER_DISABLE_TRACE
                 [[maybe_unused]] auto _ = detail::scoped_trace(
                     *this, first, last, rule_context, flags, retval);
+                #endif // BOOST_PARSER_DISABLE_TRACE
 
                 bool dont_assign = false;
                 parse_rule(
@@ -6744,8 +6799,10 @@ namespace boost { namespace parser {
             detail::flags flags,
             bool & success) const noexcept
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, detail::global_nope);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             BOOST_PARSER_SUBRANGE const where(first, first);
             auto const predicate_context = detail::make_action_context(
                 context, detail::global_nope, where);
@@ -6772,8 +6829,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             BOOST_PARSER_SUBRANGE const where(first, first);
             auto const predicate_context = detail::make_action_context(
                 context, detail::global_nope, where);
@@ -6823,8 +6882,10 @@ namespace boost { namespace parser {
             detail::flags flags,
             bool & success) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, detail::global_nope);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             if (first != last)
                 success = false;
             return {};
@@ -6845,8 +6906,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             if (first != last)
                 success = false;
         }
@@ -6875,8 +6938,10 @@ namespace boost { namespace parser {
             detail::flags flags,
             bool &) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, detail::global_nope);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             return detail::resolve(context, attr_);
         }
 
@@ -6895,8 +6960,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute_ & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             if (detail::gen_attrs(flags))
                 detail::assign_copy(retval, detail::resolve(context, attr_));
         }
@@ -6961,8 +7028,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -7126,8 +7195,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -7277,8 +7348,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -7357,8 +7430,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -7479,8 +7554,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -7643,8 +7720,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -7964,8 +8043,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             if (first == last) {
                 success = false;
@@ -8131,8 +8212,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
 
             auto compare =
                 [no_case = context.no_case_depth_](char32_t a, char32_t b) {
@@ -8220,8 +8303,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             T attr = 0;
             auto const initial = first;
             success =
@@ -8361,8 +8446,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             T attr = 0;
             auto const initial = first;
             success =
@@ -8476,8 +8563,10 @@ namespace boost { namespace parser {
             bool & success,
             Attribute & retval) const
         {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             T attr = 0;
             auto const initial = first;
             success = detail::numeric::parse_real(first, last, attr);
@@ -8570,8 +8659,10 @@ namespace boost { namespace parser {
             using attr_t = decltype(or_parser_.call(
                 first, last, context, skip, flags, success));
             attr_t attr{};
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ =
                 detail::scoped_trace(*this, first, last, context, flags, attr);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             attr = or_parser_.call(first, last, context, skip, flags, success);
             return attr;
         }
@@ -8596,8 +8687,10 @@ namespace boost { namespace parser {
                  "It looks like you tried to write switch_(val).  You need at "
                  "least one alternative, like: switch_(val)(value_1, "
                  "parser_1)(value_2, parser_2)..."));
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             [[maybe_unused]] auto _ = detail::scoped_trace(
                 *this, first, last, context, flags, retval);
+            #endif // BOOST_PARSER_DISABLE_TRACE
             or_parser_.call(first, last, context, skip, flags, success, retval);
         }
 
@@ -9055,10 +9148,13 @@ namespace boost { namespace parser {
                 "If you're seeing this error, you're trying to get parse() to "
                 "fill in attr above, using the attribute generated by parser. "
                 "However, parser does not generate an attribute.");
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return reset = detail::parse_impl<true>(
                            first, last, parser, parser.error_handler_, attr);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return reset = detail::parse_impl<false>(
                            first, last, parser, parser.error_handler_, attr);
             }
@@ -9073,10 +9169,13 @@ namespace boost { namespace parser {
                 "If you're seeing this error, you're trying to get parse() to "
                 "fill in attr above, using the attribute generated by parser. "
                 "However, parser does not generate an attribute.");
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return reset = detail::parse_impl<true>(
                            f, l, parser, parser.error_handler_, attr);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return reset = detail::parse_impl<false>(
                            f, l, parser, parser.error_handler_, attr);
             }
@@ -9177,10 +9276,13 @@ namespace boost { namespace parser {
         trace trace_mode = trace::off)
     {
         if constexpr (!detail::is_char8_iter_v<I>) {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::parse_impl<true>(
                     first, last, parser, parser.error_handler_);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::parse_impl<false>(
                     first, last, parser, parser.error_handler_);
             }
@@ -9190,10 +9292,13 @@ namespace boost { namespace parser {
             auto f = r.begin();
             auto const l = r.end();
             auto _ = detail::scoped_base_assign(first, f);
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::parse_impl<true>(
                     f, l, parser, parser.error_handler_);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::parse_impl<false>(
                     f, l, parser, parser.error_handler_);
             }
@@ -9296,6 +9401,7 @@ namespace boost { namespace parser {
                 "If you're seeing this error, you're trying to get parse() to "
                 "fill in attr above, using the attribute generated by parser. "
                 "However, parser does not generate an attribute.");
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return reset = detail::skip_parse_impl<true>(
                            first,
@@ -9304,7 +9410,9 @@ namespace boost { namespace parser {
                            skip,
                            parser.error_handler_,
                            attr);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return reset = detail::skip_parse_impl<false>(
                            first,
                            last,
@@ -9324,10 +9432,13 @@ namespace boost { namespace parser {
                 "If you're seeing this error, you're trying to get parse() to "
                 "fill in attr above, using the attribute generated by parser. "
                 "However, parser does not generate an attribute.");
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return reset = detail::skip_parse_impl<true>(
                            f, l, parser, skip, parser.error_handler_, attr);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return reset = detail::skip_parse_impl<false>(
                            f, l, parser, skip, parser.error_handler_, attr);
             }
@@ -9429,10 +9540,13 @@ namespace boost { namespace parser {
         trace trace_mode = trace::off)
     {
         if constexpr (!detail::is_char8_iter_v<I>) {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::skip_parse_impl<true>(
                     first, last, parser, skip, parser.error_handler_);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::skip_parse_impl<false>(
                     first, last, parser, skip, parser.error_handler_);
             }
@@ -9442,10 +9556,13 @@ namespace boost { namespace parser {
             auto f = r.begin();
             auto const l = r.end();
             auto _ = detail::scoped_base_assign(first, f);
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::skip_parse_impl<true>(
                     f, l, parser, skip, parser.error_handler_);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::skip_parse_impl<false>(
                     f, l, parser, skip, parser.error_handler_);
             }
@@ -9546,10 +9663,13 @@ namespace boost { namespace parser {
         trace trace_mode = trace::off)
     {
         if constexpr (!detail::is_char8_iter_v<I>) {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::callback_parse_impl<true>(
                     first, last, parser, parser.error_handler_, callbacks);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::callback_parse_impl<false>(
                     first, last, parser, parser.error_handler_, callbacks);
             }
@@ -9559,10 +9679,13 @@ namespace boost { namespace parser {
             auto f = r.begin();
             auto const l = r.end();
             auto _ = detail::scoped_base_assign(first, f);
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::callback_parse_impl<true>(
                     f, l, parser, parser.error_handler_, callbacks);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::callback_parse_impl<false>(
                     f, l, parser, parser.error_handler_, callbacks);
             }
@@ -9671,6 +9794,7 @@ namespace boost { namespace parser {
         trace trace_mode = trace::off)
     {
         if constexpr (!detail::is_char8_iter_v<I>) {
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::callback_skip_parse_impl<true>(
                     first,
@@ -9679,7 +9803,9 @@ namespace boost { namespace parser {
                     skip,
                     parser.error_handler_,
                     callbacks);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::callback_skip_parse_impl<false>(
                     first,
                     last,
@@ -9694,10 +9820,13 @@ namespace boost { namespace parser {
             auto f = r.begin();
             auto const l = r.end();
             auto _ = detail::scoped_base_assign(first, f);
+            #ifndef BOOST_PARSER_DISABLE_TRACE
             if (trace_mode == trace::on) {
                 return detail::callback_skip_parse_impl<true>(
                     f, l, parser, skip, parser.error_handler_, callbacks);
-            } else {
+            } else
+            #endif // BOOST_PARSER_DISABLE_TRACE
+            {
                 return detail::callback_skip_parse_impl<false>(
                     f, l, parser, skip, parser.error_handler_, callbacks);
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ add_test_executable(parser_seq_permutations_1)
 add_test_executable(parser_seq_permutations_2)
 add_test_executable(parser_or_permutations_1)
 add_test_executable(parser_or_permutations_2)
+add_test_executable(disable_trace)
 
 if (MSVC)
     add_executable(vs_output_tracing tracing.cpp)

--- a/test/disable_trace.cpp
+++ b/test/disable_trace.cpp
@@ -1,0 +1,27 @@
+/**
+*   Copyright (C) 2025
+ *
+ *   Distributed under the Boost Software License, Version 1.0. (See
+ *   accompanying file LICENSE_1_0.txt or copy at
+ *   http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#define BOOST_PARSER_DISABLE_TRACE
+
+#include <boost/core/lightweight_test.hpp>
+#include <boost/parser/parser.hpp>
+
+int main()
+{
+    namespace bp = boost::parser;
+    {
+        auto const parser =
+            bp::string("FOO") >> -(bp::string("bar") | bp::string("foo"));
+
+        auto result = bp::parse("FOOfoo", parser);
+        BOOST_TEST(result);
+        BOOST_TEST(bp::get(*result, bp::llong<0>{}) == std::string("FOO"));
+        BOOST_TEST(bp::get(*result, bp::llong<1>{}) == std::string("foo"));
+    }
+    return boost::report_errors();
+}


### PR DESCRIPTION
The trace feature doubles the compile time, even if never used. This patch introduces the preprocessor define BOOST_PARSER_DISABLE_TRACE to deactivate this feature at compile time.