### PR TITLE
Fix error in drone CI

### DIFF
--- a/include/boost/parser/detail/stl_interfaces/view_adaptor.hpp
+++ b/include/boost/parser/detail/stl_interfaces/view_adaptor.hpp
@@ -259,7 +259,7 @@ namespace boost::parser::detail { namespace stl_interfaces {
     template<typename F>
     struct closure : range_adaptor_closure<closure<F>>
     {
-        constexpr closure(F f) : f_(f) {}
+        constexpr closure(F f) : f_(std::move(f)) {}
 
 #if BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS
         template<typename T>


### PR DESCRIPTION
error: call to implicitly-deleted copy constructor of [snip]
constexpr closure(F f) : f_(f) {}

Full error was:

```
In file included from libs/parser/test/transform_replace.cpp:9:

In file included from ./boost/parser/transform_replace.hpp:4:

In file included from ./boost/parser/replace.hpp:4:

In file included from ./boost/parser/search.hpp:4:

In file included from ./boost/parser/parser.hpp:9:

In file included from ./boost/parser/parser_fwd.hpp:10:

In file included from ./boost/parser/error_handling_fwd.hpp:6:

In file included from ./boost/parser/detail/text/transcode_view.hpp:14:

./boost/parser/detail/stl_interfaces/view_adaptor.hpp:262:34: error: call to implicitly-deleted copy constructor of 'boost::parser::detail::stl_interfaces::detail::bind_back_t<boost::parser::detail::transform_replace_impl, boost::parser::detail::text::utf16_view<boost::parser::detail::text::detail::owning_view<boost::parser::subrange<const char *, boost::parser::detail::text::null_sentinel_t>>>, boost::parser::parser_interface<boost::parser::delimited_seq_parser<boost::parser::int_parser<int, 10, 1, -1>, boost::parser::omit_parser<boost::parser::char_parser<char>>>>, boost::parser::parser_interface<boost::parser::ws_parser<false, false>>, (lambda at libs/parser/test/transform_replace.cpp:116:17)>'

        constexpr closure(F f) : f_(f) {}
```