### PR TITLE
Replace C-style casts by std::forward

### DIFF
--- a/include/boost/parser/detail/stl_interfaces/detail/pipeable_view.hpp
+++ b/include/boost/parser/detail/stl_interfaces/detail/pipeable_view.hpp
@@ -68,23 +68,23 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
     {
         template<typename R>
         friend constexpr auto operator|(R && r, Derived & d)
-            -> decltype(((Derived &&) d)((R &&) r))
+            -> decltype((std::forward<Derived>(d))(std::forward<R>(r)))
         {
-            return ((Derived &&) d)((R &&) r);
+            return (std::forward<Derived>(d))(std::forward<R>(r));
         }
 
         template<typename R>
         friend constexpr auto operator|(R && r, Derived const & d)
-            -> decltype(((Derived &&) d)((R &&) r))
+            -> decltype((std::forward<Derived>(d))(std::forward<R>(r)))
         {
-            return ((Derived &&) d)((R &&) r);
+            return (std::forward<Derived>(d))(std::forward<R>(r));
         }
 
         template<typename R>
         friend constexpr auto operator|(R && r, Derived && d)
-            -> decltype(((Derived &&) d)((R &&) r))
+            -> decltype((std::forward<Derived>(d))(std::forward<R>(r)))
         {
-            return ((Derived &&) d)((R &&) r);
+            return (std::forward<Derived>(d))(std::forward<R>(r));
         }
     };
 
@@ -109,10 +109,10 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
 #else
         template<typename R>
         constexpr auto
-        operator()(R && r) & -> decltype(this->right_(this->left_((R &&) r)))
+        operator()(R && r) & -> decltype(this->right_(this->left_(std::forward<R>(r))))
 #endif
         {
-            return right_(left_((R &&) r));
+            return right_(left_(std::forward<R>(r)));
         }
 
 #if BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS
@@ -123,10 +123,10 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
 #else
         template<typename R>
         constexpr auto operator()(
-            R && r) const & -> decltype(this->right_(this->left_((R &&) r)))
+            R && r) const & -> decltype(this->right_(this->left_(std::forward<R>(r))))
 #endif
         {
-            return right_(left_((R &&) r));
+            return right_(left_(std::forward<R>(r)));
         }
 
 #if BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS
@@ -137,10 +137,10 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
 #else
         template<typename R>
         constexpr auto operator()(R && r) && -> decltype(std::move(
-            this->right_)(std::move(this->left_)((R &&) r)))
+            this->right_)(std::move(this->left_)(std::forward<R>(r))))
 #endif
         {
-            return std::move(right_)(std::move(left_)((R &&) r));
+            return std::move(right_)(std::move(left_)(std::forward<R>(r)));
         }
 
         T left_;

--- a/include/boost/parser/detail/stl_interfaces/detail/view_closure.hpp
+++ b/include/boost/parser/detail/stl_interfaces/detail/view_closure.hpp
@@ -40,10 +40,10 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
 #else
         template<typename R>
         constexpr auto operator()(R && r) & -> decltype(
-            Func{}((R &&) r, std::declval<box<I, T> &>().value_...))
+            Func{}(std::forward<R>(r), std::declval<box<I, T> &>().value_...))
 #endif
         {
-            return Func{}((R &&) r, static_cast<box<I, T> &>(*this).value_...);
+            return Func{}(std::forward<R>(r), static_cast<box<I, T> &>(*this).value_...);
         }
 
 #if BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS
@@ -55,11 +55,11 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
 #else
         template<typename R>
         constexpr auto operator()(R && r) const & -> decltype(
-            Func{}((R &&) r, std::declval<box<I, T> const &>().value_...))
+            Func{}(std::forward<R>(r), std::declval<box<I, T> const &>().value_...))
 #endif
         {
             return Func{}(
-                (R &&) r, static_cast<box<I, T> const &>(*this).value_...);
+                std::forward<R>(r), static_cast<box<I, T> const &>(*this).value_...);
         }
 
 #if BOOST_PARSER_DETAIL_STL_INTERFACES_USE_CONCEPTS
@@ -71,10 +71,10 @@ namespace boost::parser::detail { namespace stl_interfaces { namespace detail {
 #else
         template<typename R>
         constexpr auto operator()(R && r) && -> decltype(
-            Func{}((R &&) r, std::declval<box<I, T> &&>().value_...))
+            Func{}(std::forward<R>(r), std::declval<box<I, T> &&>().value_...))
 #endif
         {
-            return Func{}((R &&) r, static_cast<box<I, T> &&>(*this).value_...);
+            return Func{}(std::forward<R>(r), static_cast<box<I, T> &&>(*this).value_...);
         }
     };
 

--- a/include/boost/parser/detail/text/detail/all_t.hpp
+++ b/include/boost/parser/detail/text/detail/all_t.hpp
@@ -122,7 +122,7 @@ namespace boost::parser::detail::text::detail {
         {
             using T = remove_cv_ref_t<R>;
             if constexpr (view<T>)
-                return (R &&) r;
+                return std::forward<R>(r);
             else if constexpr (can_ref_view<R>)
                 return ref_view(r);
             else

--- a/include/boost/parser/replace.hpp
+++ b/include/boost/parser/replace.hpp
@@ -612,10 +612,10 @@ namespace boost::parser {
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, skip, replacement, trace) case
                     return impl(
-                        (R &&) r,
+                        std::forward<R>(r),
                         parser,
                         skip,
-                        (ReplacementR &&) replacement,
+                        std::forward<ReplacementR>(replacement),
                         trace_mode);
                 } else if constexpr (
                     is_range<remove_cv_ref_t<SkipParser>> &&
@@ -623,10 +623,10 @@ namespace boost::parser {
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, replacement, trace) case
                     return impl(
-                        (R &&) r,
+                        std::forward<R>(r),
                         parser,
                         parser_interface<eps_parser<detail::phony>>{},
-                        (SkipParser &&) skip,
+                        std::forward<SkipParser>(skip),
                         replacement);
                 } else {
                     static_assert(
@@ -654,7 +654,7 @@ namespace boost::parser {
                 trace trace_mode = trace::off) const
             {
                 return replace_view(
-                    to_range<R>::call((R &&) r),
+                    to_range<R>::call(std::forward<R>(r)),
                     parser,
                     skip,
                     to_range<

--- a/include/boost/parser/search.hpp
+++ b/include/boost/parser/search.hpp
@@ -52,7 +52,7 @@ namespace boost::parser {
                             return BOOST_PARSER_SUBRANGE(
                                 first, plus_strlen(first));
                         } else {
-                            return (R &&) r;
+                            return std::forward<R>(r);
                         }
                     } else {
                         if constexpr (ToCommonRange) {
@@ -60,7 +60,7 @@ namespace boost::parser {
                                 first, plus_strlen(first)) |
                                    as_utf<OtherRangeFormat>;
                         } else {
-                            return (R &&) r | as_utf<OtherRangeFormat>;
+                            return std::forward<R>(r) | as_utf<OtherRangeFormat>;
                         }
                     }
                 } else if constexpr (text::detail::is_bounded_array_v<T>) {
@@ -76,7 +76,7 @@ namespace boost::parser {
                                as_utf<OtherRangeFormat>;
                     }
                 } else {
-                    return (R &&) r | as_utf<OtherRangeFormat>;
+                    return std::forward<R>(r) | as_utf<OtherRangeFormat>;
                 }
             }
         };
@@ -87,7 +87,7 @@ namespace boost::parser {
             template<typename R>
             static constexpr R && call(R && r)
             {
-                return (R &&) r;
+                return std::forward<R>(r);
             }
         };
 
@@ -150,7 +150,7 @@ namespace boost::parser {
         {
             using value_type = range_value_t<decltype(r)>;
             if constexpr (std::is_same_v<value_type, char>) {
-                return detail::search_impl((R &&) r, parser, skip, trace_mode);
+                return detail::search_impl(std::forward<R>(r), parser, skip, trace_mode);
             } else {
                 auto r_unpacked = detail::text::unpack_iterator_and_sentinel(
                     text::detail::begin(r), text::detail::end(r));
@@ -194,7 +194,7 @@ namespace boost::parser {
         trace trace_mode = trace::off)
     {
         return detail::search_repack_shim(
-            detail::to_range<R>::call((R &&) r), parser, skip, trace_mode);
+            detail::to_range<R>::call(std::forward<R>(r)), parser, skip, trace_mode);
     }
 
     /** Returns a subrange to the first match for parser `parser` in `[first,
@@ -255,7 +255,7 @@ namespace boost::parser {
         trace trace_mode = trace::off)
     {
         return parser::search(
-            (R &&) r,
+            std::forward<R>(r),
             parser,
             parser_interface<eps_parser<detail::phony>>{},
             trace_mode);
@@ -607,7 +607,7 @@ namespace boost::parser {
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, trace) case
                     return impl(
-                        (R &&) r,
+                        std::forward<R>(r),
                         parser,
                         parser_interface<eps_parser<detail::phony>>{},
                         skip);
@@ -615,7 +615,7 @@ namespace boost::parser {
                     detail::is_parser_iface<SkipParser> &&
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, skip, trace) case
-                    return impl((R &&) r, parser, skip, trace_mode);
+                    return impl(std::forward<R>(r), parser, skip, trace_mode);
                 } else {
                     static_assert(
                         sizeof(R) == 1 && false,
@@ -640,7 +640,7 @@ namespace boost::parser {
                 trace trace_mode = trace::off) const
             {
                 return search_all_view(
-                    to_range<R>::call((R &&) r), parser, skip, trace_mode);
+                    to_range<R>::call(std::forward<R>(r)), parser, skip, trace_mode);
             }
 
 #endif

--- a/include/boost/parser/split.hpp
+++ b/include/boost/parser/split.hpp
@@ -324,7 +324,7 @@ namespace boost::parser {
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, trace) case
                     return impl(
-                        (R &&) r,
+                        std::forward<R>(r),
                         parser,
                         parser_interface<eps_parser<detail::phony>>{},
                         skip);
@@ -332,7 +332,7 @@ namespace boost::parser {
                     detail::is_parser_iface<SkipParser> &&
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, skip, trace) case
-                    return impl((R &&) r, parser, skip, trace_mode);
+                    return impl(std::forward<R>(r), parser, skip, trace_mode);
                 } else {
                     static_assert(
                         sizeof(R) == 1 && false,
@@ -357,7 +357,7 @@ namespace boost::parser {
                 trace trace_mode = trace::off) const
             {
                 return split_view(
-                    to_range<R>::call((R &&) r), parser, skip, trace_mode);
+                    to_range<R>::call(std::forward<R>(r)), parser, skip, trace_mode);
             }
 
 #endif

--- a/include/boost/parser/transform_replace.hpp
+++ b/include/boost/parser/transform_replace.hpp
@@ -292,7 +292,7 @@ namespace boost::parser {
             using value_type = range_value_t<decltype(r)>;
             if constexpr (std::is_same_v<value_type, char>) {
                 return detail::attr_search_impl(
-                    (R &&) r, parser, skip, trace_mode);
+                    std::forward<R>(r), parser, skip, trace_mode);
             } else {
                 auto r_unpacked = detail::text::unpack_iterator_and_sentinel(
                     text::detail::begin(r), text::detail::end(r));
@@ -741,7 +741,7 @@ namespace boost::parser {
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, skip, f, trace) case
                     return impl(
-                        to_range<R>::call((R &&) r),
+                        to_range<R>::call(std::forward<R>(r)),
                         parser,
                         skip,
                         (F &&) f,
@@ -754,10 +754,10 @@ namespace boost::parser {
                     std::is_same_v<Trace, trace>) {
                     // (r, parser, f, trace) case
                     return impl(
-                        to_range<R>::call((R &&) r),
+                        to_range<R>::call(std::forward<R>(r)),
                         parser,
                         parser_interface<eps_parser<detail::phony>>{},
-                        (SkipParser &&) skip,
+                        std::forward<SkipParser>(skip),
                         f);
                 } else {
                     static_assert(
@@ -785,7 +785,7 @@ namespace boost::parser {
                 trace trace_mode = trace::off) const
             {
                 return transform_replace_view(
-                    (R &&) r,
+                    std::forward<R>(r),
                     parser,
                     skip,
                     utf_rvalue_shim<


### PR DESCRIPTION
Note that std::forward<T> ist just a
static_cast<T&&>, see
https://eel.is/c++draft/forward#3

I hope that this fixes some of the errors in Drone-CI with Clang 13 like the following
```
./boost/parser/search.hpp:55:36: error: call to implicitly-deleted copy constructor of 'boost::parser::detail::text::utf16_view<boost::parser::detail::text::detail::owning_view<boost::parser::subrange<const char *, boost::parser::detail::text::null_sentinel_t>>>'
                            return (R &&) r;
```