### PR TITLE
fix optional quoted strings

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -7635,9 +7635,10 @@ namespace boost { namespace parser {
 
             auto const prev_first = first;
 
-            auto append = [&retval,
+            std::string result;
+            auto append = [&result,
                            gen_attrs = detail::gen_attrs(flags)](auto & ctx) {
-                detail::move_back(retval, _attr(ctx), gen_attrs);
+                detail::move_back(result, _attr(ctx), gen_attrs);
             };
 
             auto quote_ch = [&]() {
@@ -7698,6 +7699,9 @@ namespace boost { namespace parser {
             if (!success) {
                 retval = Attribute();
                 first = prev_first;
+            }
+            else{
+                retval = std::move(result);
             }
         }
 


### PR DESCRIPTION
Optional quoted string parsers are currently not possible because the result type std::optional<std::string> cannot be handled as a container. 

This was fixed by appending the result to an std::string first, then moving it into the std::optional<std::string>. 
 
Example for reproduction of the bug:
`auto const pTest = (bp::lit("TEST:") > -bp::quoted_string`

A possible workaround: 
`auto const pTest = (bp::lit("TEST:") > (bp::quoted_string | bp::eps)`