### PR TITLE
Improve error visualization.

### DIFF
--- a/include/boost/parser/error_handling.hpp
+++ b/include/boost/parser/error_handling.hpp
@@ -90,6 +90,9 @@ namespace boost { namespace parser {
         os << ":\n";
 
         std::string underlining(std::distance(position.line_start, it), ' ');
+        std::transform(position.line_start, it,
+            underlining.begin(),
+            [](auto c) { return c == '\t' ? '\t' : ' ';});
         detail::trace_input(os, position.line_start, it, false, 1u << 31);
         if (it == last) {
             os << '\n' << underlining << "^\n";


### PR DESCRIPTION
If the parsed string contains tab characters on the failing line, the underlining in the error message pointed to the wrong position.

This patch adds as many tab characters to the underlining as there are in the parsed line. So the underlining points to the correct position.