### PR TITLE
use fold expressions in or_parser and seq_parser

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -3529,7 +3529,9 @@ namespace boost { namespace parser {
                 else
                     use_parser.first_ = prev_first;
             };
-            detail::hl::for_each(parsers_, try_parser); // TODO: -> fold-expr
+            std::apply([&try_parser](auto&&... args) {
+                ((try_parser(args)), ...);
+            }, parsers_);
 
             if (!done)
                 success = false;
@@ -4578,7 +4580,9 @@ namespace boost { namespace parser {
 
             auto const parsers_and_indices =
                 detail::hl::zip(parsers_, indices, merged, backtracking{});
-            detail::hl::for_each(parsers_and_indices, use_parser);
+            std::apply([&use_parser](auto&&... args) {
+                ((use_parser(args)), ...);
+            }, parsers_and_indices);
         }
 
         template<bool AllowBacktracking, typename Parser>


### PR DESCRIPTION
In the code, there was a TODO not to use fold expressions instead of detail::hl::for_each.

I do not know why one would prefer the fold expression, but as there is the TODO note I just did it.