### PR TITLE
update CI from macos-13 to macos-15

### DIFF
--- a/.github/workflows/macos-15.yml
+++ b/.github/workflows/macos-15.yml
@@ -1,4 +1,4 @@
-name: macos-13 - Clang 14
+name: macos-15 - Clang
 
 on:
   push:
@@ -14,9 +14,9 @@ jobs:
   build:
     strategy:
       matrix:
-        cxx_std: [17]
+        cxx_std: [17, 20]
 
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
MacOS 13 is retired in github actions, see
https://github.com/actions/runner-images/issues/13046