### PR TITLE
remove CMAKE_BUILD_TYPE from Windows CI configuration

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,13 +24,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure CMake
-        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # Configure CMake in a 'build' subdirectory. Visual Studio is a multi-config generator, so we don't use CMAKE_BUILD_TYPE.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCXX_STD=${{ matrix.cxx_std }}
+        run: cmake -B build -DCXX_STD=${{ matrix.cxx_std }}
 
       - name: Build
         working-directory: build
-        run: cmake --build . -- /p:CL_MPcount=4
+        run: cmake --build . --config ${{ env.BUILD_TYPE }} -- /p:CL_MPcount=4
 
       - name: Test
         working-directory: build/test


### PR DESCRIPTION
For Visual Studio, cmake generates just one vcxproj for all configurations. The presence of CMAKE_BUILD_TYPE on the command line leads to a warning.