### PR TITLE
Move values into detail::assign

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -3713,7 +3713,7 @@ namespace boost { namespace parser {
                     if constexpr (detail::is_struct_compatible_v<
                                       Attribute,
                                       result_t>) {
-                        detail::assign(retval, temp_retval);
+                        detail::assign(retval, std::move(temp_retval));
                     } else {
                         detail::assign(
                             retval,
@@ -5485,7 +5485,7 @@ namespace boost { namespace parser {
                     dont_assign);
                 if (success && !dont_assign) {
                     if constexpr (!detail::is_nope_v<decltype(attr)>)
-                        detail::assign(retval, attr);
+                        detail::assign(retval, std::move(attr));
                 }
             }
 
@@ -5580,7 +5580,7 @@ namespace boost { namespace parser {
                     container<Attribute_> && container<attr_type>) {
                     detail::move_back(retval, attr, detail::gen_attrs(flags));
                 } else {
-                    detail::assign(retval, attr);
+                    detail::assign(retval, std::move(attr));
                 }
             }
         }


### PR DESCRIPTION
Code cleanup:
Most of the time, values are std::moved into detail::assign, but not always. This patch makes usage more consistent to always use std::move, except for ints, floats, and iterators.