### PR TITLE
Allow move-only attributes

### DIFF
--- a/include/boost/parser/detail/printing.hpp
+++ b/include/boost/parser/detail/printing.hpp
@@ -593,7 +593,7 @@ namespace boost { namespace parser { namespace detail {
     }
 
     template<typename Context, typename T>
-    auto resolve(Context const & context, T const & x);
+    decltype(auto) resolve(Context const & context, T const & x);
 
     template<typename Context>
     auto resolve(Context const &, nope n);

--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -1020,7 +1020,7 @@ namespace boost { namespace parser {
             bool Callable = is_detected_v<callable, T const &, Context const &>>
         struct resolve_impl
         {
-            static auto call(Context const &, T const & x) { return x; }
+            static auto& call(Context const &, T const & x) { return x; }
         };
 
         template<typename Context, typename T>
@@ -1033,7 +1033,7 @@ namespace boost { namespace parser {
         };
 
         template<typename Context, typename T>
-        auto resolve(Context const & context, T const & x)
+        decltype(auto) resolve(Context const & context, T const & x)
         {
             return resolve_impl<Context, T>::call(context, x);
         }
@@ -4328,7 +4328,7 @@ namespace boost { namespace parser {
             // A 1-tuple is converted to a scalar.
             if constexpr (detail::hl::size(retval) == llong<1>{}) {
                 using namespace literals;
-                return parser::get(retval, 0_c);
+                return parser::get(std::move(retval), 0_c);
             } else {
                 return retval;
             }
@@ -5485,7 +5485,7 @@ namespace boost { namespace parser {
                     dont_assign);
                 if (success && !dont_assign) {
                     if constexpr (!detail::is_nope_v<decltype(attr)>)
-                        detail::assign(retval, attr);
+                        detail::assign(retval, std::move(attr));
                 }
             }
 
@@ -5580,7 +5580,7 @@ namespace boost { namespace parser {
                     container<Attribute_> && container<attr_type>) {
                     detail::move_back(retval, attr, detail::gen_attrs(flags));
                 } else {
-                    detail::assign(retval, attr);
+                    detail::assign(retval, std::move(attr));
                 }
             }
         }


### PR DESCRIPTION
This tests the usage of move-only attributes.
parser.hpp and printing.hpp are slightly modified to make it work.